### PR TITLE
Add missing return to an assignment operator in the test

### DIFF
--- a/inline_variant_test.cpp
+++ b/inline_variant_test.cpp
@@ -53,6 +53,7 @@ struct copy_counter
     copy_counter& operator=(copy_counter const& other) {
         copy_count_ = other.copy_count_;
         ++(*copy_count_);
+        return *this;
     }
 
     int * copy_count_;


### PR DESCRIPTION
This fixes the test compilation with MSVS 2015.
